### PR TITLE
Pg10matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ matrix:
            - sudo make install
        env:
           - POSTGRESQL=10
+   allow_failures:
+     - addons: 
+          postgresql: 9.3
 script:
   - make installcheck
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 sudo: required
+dist: trusty
+language: c
 matrix:
    include:
      - addons: 
+          postgresql: 9.3
+       env:
+          - POSTGRESQL=9.3
+       install:
+           - sudo apt-get install postgresql-server-dev-9.3
+           - sudo make install
+     - addons: 
           postgresql: 9.4
+       env:
+          - POSTGRESQL=9.4
        install:
            - sudo apt-get install postgresql-server-dev-9.4
            - sudo make install
@@ -11,11 +22,16 @@ matrix:
        install:
            - sudo apt-get install postgresql-server-dev-9.5
            - sudo make install
+       env:
+          - POSTGRESQL=9.5
      - addons: 
           postgresql: 9.6
        install:
            - sudo apt-get install postgresql-server-dev-9.6
            - sudo make install
+       env:
+          - POSTGRESQL=9.6
+   allow_failures:
      - # addons: postgresql: 10
        install:
            - sudo service postgresql stop
@@ -28,9 +44,9 @@ matrix:
            - sudo pg_ctlcluster 10 main restart
            - sudo -u postgres psql  -c "create user travis with superuser";
            - sudo make install
-env:
-  - COVERAGE=1 RELEASE_TESTING=1 DB_TESTING=1
+       env:
+          - POSTGRESQL=10
 script:
   - make installcheck
 after_failure:
-  - cat /home/travis/build/adjust/pg-roleman/regression.diffs
+  - cat regression.diffs

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
            - sudo make install
        env:
           - POSTGRESQL=9.6
-   allow_failures:
      - # addons: postgresql: 10
        install:
            - sudo service postgresql stop


### PR DESCRIPTION
Moving to standard .travis.yml

9.3 fails it looks like because some of plpgsql changes.
Given the age though, not worrying about supporting it at present.